### PR TITLE
Minor changes for testing, downloadable attachments

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,7 @@ def create_app(db_url=None):
 
     app = Flask(__name__)
     # CORS(app, origins=[os.getenv("FRONTEND_URL")])
+    CORS(app, origins=["*"])
 
     app.config["PROPAGATE_EXCEPTIONS"] = True
     app.config["API_TITLE"] = "Precision Medicine Portal REST API"

--- a/app.py
+++ b/app.py
@@ -32,6 +32,7 @@ def create_app(db_url=None):
     app.config["OPENAPI_SWAGGER_UI_URL"] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist/"
     app.config["SQLALCHEMY_DATABASE_URI"] = db_url or os.getenv("DATABASE_URL", "sqlite:///data.db")
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    app.config["FASTA_DIR"] = ROOT_DIR + "/data/out/"
 
     db.init_app(app)
     migrate = Migrate(app, db)

--- a/resources/immunediscoverdata.py
+++ b/resources/immunediscoverdata.py
@@ -2,6 +2,7 @@ from flask.views import MethodView
 from flask_smorest import Blueprint, abort
 # from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 from flask import send_from_directory
+from flask import send_file
 
 from constants import ROOT_DIR
 from models import ImmuneDiscoverDataModel
@@ -38,8 +39,8 @@ class ImmuneDiscoverDataList(MethodView):
     def get(self, allele_name):
         return calculate_allele_frequencies(allele_name)
     
-@blp.route("/fastas/<file_name>")
+@blp.route("/fasta/<file_name>")
 def send_fasta(file_name):
     data_out_path = ROOT_DIR + '/data/out/'
-    return send_from_directory(data_out_path, file_name)
+    return send_file(data_out_path + file_name, as_attachment=True)
         

--- a/resources/immunediscoverdata.py
+++ b/resources/immunediscoverdata.py
@@ -1,7 +1,6 @@
 from flask.views import MethodView
 from flask_smorest import Blueprint, abort
 # from sqlalchemy.exc import SQLAlchemyError, IntegrityError
-from flask import send_from_directory
 from flask import send_file
 
 from constants import ROOT_DIR

--- a/resources/immunediscoverdata.py
+++ b/resources/immunediscoverdata.py
@@ -1,7 +1,8 @@
 from flask.views import MethodView
 from flask_smorest import Blueprint, abort
 # from sqlalchemy.exc import SQLAlchemyError, IntegrityError
-from flask import send_file
+from flask import current_app, send_file
+from werkzeug.utils import safe_join
 
 from constants import ROOT_DIR
 from models import ImmuneDiscoverDataModel
@@ -40,6 +41,6 @@ class ImmuneDiscoverDataList(MethodView):
     
 @blp.route("/fasta/<file_name>")
 def send_fasta(file_name):
-    data_out_path = ROOT_DIR + '/data/out/'
-    return send_file(data_out_path + file_name, as_attachment=True)
+    file_path = safe_join(current_app.config['FASTA_DIR'], file_name)
+    return send_file(file_path, as_attachment=True)
         


### PR DESCRIPTION
Allow CORS from all sources ('*'), for testing only. Will later be only from frontend.

Using Flask function 'send_file' to send .fasta files as attachments instead of plain text.